### PR TITLE
Changed the logout link from a get to a post

### DIFF
--- a/django_admin_kubi/templates/admin/menu.html
+++ b/django_admin_kubi/templates/admin/menu.html
@@ -53,7 +53,10 @@
                 <a class="dropdown-item" href="{% url 'admin:password_change' %}"><i class="fa fa-key"></i> {% trans 'Change password' %}</a>
               {% endif %}
               <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="{% url 'admin:logout' %}"><i class="fa fa-power-off"></i> {% trans 'Log out' %}</a>
+              <form id="logout-form" method="post" action="{% url 'admin:logout' %}" class="dropdown-item">
+                {% csrf_token %}
+                <button type="submit" class="link-danger"><i class="fa fa-power-off"></i> {% translate "Log out" %}</button>
+              </form>
             {% endblock %}
           </div>
         </div>


### PR DESCRIPTION
Closes issue #11 

The link was changed to a form and button, it looks like this now.
![Screenshot from 2024-04-05 16-16-43](https://github.com/dengunorg/django-admin-kubi/assets/439167/2716829e-7e0e-4962-ad06-4ce4bfa2bbbe)
